### PR TITLE
Add relative seeking

### DIFF
--- a/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_theater.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_theater.lua
@@ -502,7 +502,6 @@ if SERVER then
 		-- Seconds isn't a number, check HH:MM:SS
 		if not tonumber(seconds) then
 			local hr, min, sec = string.match(seconds, hhmmss)
-			--local curtime = self:VideoCurrentTime(true)
 
 			-- Not in HH:MM:SS, try MM:SS
 			if not hr then
@@ -514,7 +513,6 @@ if SERVER then
 			seconds = tonumber(hr) * 3600 +
 				tonumber(min) * 60 +
 				tonumber(sec)
-
 		end
 
 		-- If it's not one of those two things then it will fall trough wihtout any changes.

--- a/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_theater.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_theater.lua
@@ -496,9 +496,13 @@ if SERVER then
 
 		if not IsVideoTimed(self:VideoType()) then return end
 
+		-- Get the plus or minus sign for later.
+		local frontsign = seconds[1]
+
 		-- Seconds isn't a number, check HH:MM:SS
 		if not tonumber(seconds) then
 			local hr, min, sec = string.match(seconds, hhmmss)
+			--local curtime = self:VideoCurrentTime(true)
 
 			-- Not in HH:MM:SS, try MM:SS
 			if not hr then
@@ -510,6 +514,12 @@ if SERVER then
 			seconds = tonumber(hr) * 3600 +
 				tonumber(min) * 60 +
 				tonumber(sec)
+
+		end
+
+		-- If it's not one of those two things then it will fall trough wihtout any changes.
+		if frontsign == "+" or frontsign == "-" then
+			seconds = self:VideoCurrentTime(true) + seconds
 		end
 
 		-- Clamp video seek time between 0 and video duration
@@ -523,7 +533,6 @@ if SERVER then
 		net.Start("TheaterSeek")
 			net.WriteFloat( self:VideoStartTime() )
 		net.Send(self.Players)
-
 	end
 
 	function THEATER:SendVideo( ply )

--- a/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_theater.lua
+++ b/workshop/gamemodes/cinema_modded/gamemode/modules/theater/sh_theater.lua
@@ -497,7 +497,7 @@ if SERVER then
 		if not IsVideoTimed(self:VideoType()) then return end
 
 		-- Get the plus or minus sign for later.
-		local frontsign = seconds[1]
+		local frontsign = seconds[1] or ""
 
 		-- Seconds isn't a number, check HH:MM:SS
 		if not tonumber(seconds) then
@@ -516,8 +516,10 @@ if SERVER then
 		end
 
 		-- If it's not one of those two things then it will fall trough wihtout any changes.
-		if frontsign == "+" or frontsign == "-" then
-			seconds = self:VideoCurrentTime(true) + seconds
+		if frontsign == "+" then
+			seconds = self:VideoCurrentTime(true) + math.abs(seconds)
+		elseif frontsign == "-" then
+			seconds = self:VideoCurrentTime(true) - math.abs(seconds)
 		end
 
 		-- Clamp video seek time between 0 and video duration
@@ -531,6 +533,7 @@ if SERVER then
 		net.Start("TheaterSeek")
 			net.WriteFloat( self:VideoStartTime() )
 		net.Send(self.Players)
+
 	end
 
 	function THEATER:SendVideo( ply )


### PR DESCRIPTION
Usability improvement, make theatre seeking optionally relative with `+` or `-` signs at the start of the time stamp.
### Tested
- [x] Raw seconds
- [x] Hour-Minute-Seconds format